### PR TITLE
Fix AllExceptionsFilter type

### DIFF
--- a/packages/backend/src/core/filters/all-exceptions.filter.ts
+++ b/packages/backend/src/core/filters/all-exceptions.filter.ts
@@ -14,13 +14,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const request = ctx.getRequest();
     const response = ctx.getResponse();
 
-    let httpStatus:
-      | HttpStatus.INTERNAL_SERVER_ERROR
-      | HttpStatus.UNAUTHORIZED
-      | HttpStatus.FORBIDDEN
-      | HttpStatus.NOT_FOUND
-      | HttpStatus.BAD_REQUEST
-      | number;
+    // Narrow type to known HttpStatus values while allowing custom numeric codes
+    let httpStatus: HttpStatus | number;
     let message: string | object;
 
     if (exception instanceof HttpException) {


### PR DESCRIPTION
## Summary
- update AllExceptionsFilter to use a normal union type

## Testing
- `npx tsc -p packages/backend/tsconfig.json` *(fails: Cannot find module)*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846787322fc832d8da05e6d60c04413